### PR TITLE
Complete migration to flat src/ structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ format:
 
 check-quality:
 	@echo "Checking isort..."
-	isort --check-only src/hovercraft_analysis tests/
+	isort --check-only src/ tests/
 	@echo "Checking black..."
-	black --check src/hovercraft_analysis tests/
+	black --check src/ tests/
 	@echo "Checking flake8..."
 	flake8 src/ tests/ --config=.flake8
 	@echo "Checking mypy..."

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ make run-dashboard
 ```
 analysis-pipeline/
 ├── src/                      # Source code
-│   └── hovercraft_analysis/  # Main package
-│       ├── core/            # Core utilities
-│       ├── analysis/        # Analysis modules
-│       ├── apps/           # Applications (dashboard)
-│       └── scripts/        # CLI entry points
+│   ├── core/                # Core utilities
+│   ├── analysis/            # Analysis modules
+│   ├── apps/               # Applications (dashboard)
+│   └── scripts/            # CLI entry points
 ├── config/                  # Configuration files
 │   ├── pipeline.yaml       # Master configuration
 │   ├── experiments/        # Experiment metadata
@@ -53,7 +52,7 @@ analysis-pipeline/
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.12 or higher
 - pip
 - Make (optional but recommended)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ The Hovercraft Analysis Pipeline is a comprehensive system for processing and an
 ### Package Structure
 
 ```
-hovercraft_analysis/
+src/
 ├── core/              # Core utilities and infrastructure
 │   ├── config.py      # Configuration management
 │   ├── paths.py       # Path definitions
@@ -128,7 +128,7 @@ environments:
 ### Configuration Access
 
 ```python
-from hovercraft_analysis.core import get_config
+from src.core import get_config
 
 config = get_config()
 freq = config.get('processing.alignment.target_frequency')

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -38,7 +38,7 @@ The project uses a unified configuration system centered around a master configu
 ### Basic Usage
 
 ```python
-from hovercraft_analysis.core import get_config
+from src.core import get_config
 
 # Get the global configuration manager
 config = get_config()
@@ -162,7 +162,7 @@ output:
 ### 3. Use in Code
 
 ```python
-from hovercraft_analysis.core import get_config
+from src.core import get_config
 
 config = get_config()
 module_config = config.load_sub_config('processing.my_new_module')
@@ -226,7 +226,7 @@ If you have code using old hardcoded paths:
 data_path = "../../02_Evaluation_Experiments/afternoon/007_Fast_stbd_turn_1"
 
 # New way
-from hovercraft_analysis.core import get_experiment_path
+from src.core import get_experiment_path
 data_path = get_experiment_path("007_Fast_stbd_turn_1", "afternoon")
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -33,7 +33,7 @@ pip install -e ".[dev,notebook]"
 
 ```bash
 # Test that the package is installed
-python -c "from hovercraft_analysis.core import get_experiment_path; print('✓ Package installed successfully')"
+python -c "from src.core import get_experiment_path; print('✓ Package installed successfully')"
 
 # Run tests
 make test-fast
@@ -55,7 +55,7 @@ The dashboard will be available at http://localhost:8050
 analysis-pipeline/
 ├── config/           # Configuration files
 ├── src/              # Source code
-│   └── hovercraft_analysis/
+│   ├── core/
 │       ├── core/     # Core utilities
 │       ├── analysis/ # Analysis modules
 │       ├── apps/     # Applications (dashboard)
@@ -96,7 +96,7 @@ hovercraft-dashboard                        # Launch analysis dashboard
 
 List available experiments:
 ```python
-from hovercraft_analysis.core import get_available_experiments
+from src.core import get_available_experiments
 
 experiments = get_available_experiments()
 for exp in experiments:
@@ -106,7 +106,7 @@ for exp in experiments:
 ### Loading Experiment Data
 
 ```python
-from hovercraft_analysis.core import load_experiment_data
+from src.core import load_experiment_data
 
 # Load all data for an experiment
 data = load_experiment_data("007_Fast_stbd_turn_1", "afternoon")
@@ -119,7 +119,7 @@ accel_data = data['Sensor_3_accel']
 ### Running Analysis
 
 ```python
-from hovercraft_analysis.analysis.alignment import align_experiment_data
+from src.analysis.alignment import align_experiment_data
 
 # Align sensor data
 aligned_data = align_experiment_data("007_Fast_stbd_turn_1", "afternoon")
@@ -137,7 +137,7 @@ The project uses a unified configuration system. Main configuration file: `/conf
 ### Accessing Configuration
 
 ```python
-from hovercraft_analysis.core import get_config
+from src.core import get_config
 
 config = get_config()
 data_root = config.get('paths.data_root')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ src = [
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -129,7 +129,7 @@ line_length = 88
 skip_gitignore = true
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/src/scripts/dashboard_app.py
+++ b/src/scripts/dashboard_app.py
@@ -9,7 +9,7 @@ import time # For benchmarking if needed
 
 # Import your data loading utilities
 try:
-    from data_utils import (
+    from src.scripts.data_utils import (
         load_experiment_data,
         list_experiment_types,
         list_experiments,


### PR DESCRIPTION
- Update Python version requirements from 3.8 to 3.12 throughout
- Fix all remaining hovercraft_analysis import references
- Update Makefile paths to use src/ directly
- Fix dashboard imports to use absolute paths
- Update documentation to reflect consolidated structure
