### PR TITLE
docs: Update documentation to reflect repository consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ hovercraft-orientation --experiment 011_Static_stbd_1
 ### Python API
 
 ```python
-from hovercraft_analysis.core import load_experiment_data
-from hovercraft_analysis.analysis.alignment import align_experiment_data
+from src.core import load_experiment_data
+from src.analysis.alignment import align_experiment_data
 
 # Load experiment data
 data = load_experiment_data("007_Fast_stbd_turn_1", "afternoon")
@@ -176,7 +176,7 @@ The project uses a unified configuration system. The master configuration file i
 ### Configuration Access
 
 ```python
-from hovercraft_analysis.core import get_config
+from src.core import get_config
 
 config = get_config()
 data_root = config.get('paths.data_root')

--- a/SETUP.md
+++ b/SETUP.md
@@ -4,7 +4,7 @@ This guide will help you set up the hovercraft analysis pipeline development env
 
 ## Prerequisites
 
-- Python 3.8 or higher
+- Python 3.12 or higher
 - Git
 - Access to the experimental data (in `/data` directory)
 
@@ -25,48 +25,61 @@ This guide will help you set up the hovercraft analysis pipeline development env
    source venv/bin/activate
    ```
 
-3. **Install dependencies**:
+3. **Install the package in development mode**:
    ```bash
    pip install --upgrade pip
-   pip install -r requirements.txt
-   ```
-
-4. **Install the package in development mode** (coming in Phase 2):
-   ```bash
-   # This will be available after Phase 2 implementation
-   # pip install -e .
+   pip install -e ".[dev]"
    ```
 
 ## Project Structure
 
 ```
 analysis-pipeline/
-├── code/              # All Python source code
-│   ├── alignment_analysis/
-│   ├── dashboard_app/
-│   ├── orientation_analysis/
-│   ├── timestamp_analysis/
-│   ├── rpm_estimation/
-│   ├── scripts/       # Standalone scripts
-│   ├── notebooks/     # Jupyter notebooks
-│   └── config/        # Configuration files
-├── data/              # Experimental data
-│   ├── morning/
-│   └── afternoon/
-├── docs/              # Documentation
-├── tests/             # All test files (centralized)
-│   ├── alignment/
-│   ├── orientation/
-│   ├── rpm_estimation/
-│   ├── scripts/
-│   └── timestamp/
-└── notes/             # Thesis notes
+├── /config                    # Master configuration directory
+│   ├── pipeline.yaml         # Master configuration file
+│   ├── /experiments          # Experiment mappings and metadata
+│   ├── /sensors             # Sensor specifications and orientations
+│   └── /processing          # Module-specific processing configs
+├── /src                      # All source code (consolidated)
+│   ├── /core                # Core utilities and config management
+│   ├── /analysis            # Analysis modules
+│   │   ├── /alignment       # Time alignment
+│   │   ├── /orientation     # Sensor orientation
+│   │   ├── /rpm            # RPM estimation
+│   │   └── /timestamp      # Timestamp analysis
+│   ├── /apps               # Applications
+│   │   └── /dashboard      # Dashboard app modules
+│   ├── /scripts            # Command-line scripts
+│   ├── /notebooks          # Jupyter notebooks
+│   └── /plans              # Development plans
+├── /data                     # All experimental and processed data
+│   ├── /raw                 # Raw experimental data
+│   │   ├── /morning/Experiments/  # Morning session experiments
+│   │   └── /afternoon/Experiments/ # Afternoon session experiments
+│   ├── /processed           # All processed outputs
+│   │   ├── /aligned        # Time-aligned sensor data
+│   │   ├── /orientation    # Orientation analysis results
+│   │   ├── /rpm           # RPM estimation results
+│   │   └── /timestamp     # Timestamp analysis results
+│   └── /cache              # Temporary files and cache
+├── /docs                     # Documentation
+│   ├── /config              # Config documentation only
+│   ├── /results             # Analysis results by thesis WPs
+│   ├── /development         # Development docs
+│   └── /experimental_setup  # Experiment documentation
+├── /tests                    # Centralized test suite
+├── .github/workflows         # CI/CD configuration
+├── pyproject.toml           # Python package configuration
+├── Makefile                # Build automation
+└── README.md               # Project overview
 ```
 
 ## Running Tests
 
 Run all tests:
 ```bash
+make test-fast
+# or
 python -m pytest tests/
 ```
 
@@ -79,77 +92,113 @@ python -m pytest tests/rpm_estimation/
 
 Run with coverage:
 ```bash
-python -m pytest tests/ --cov=code --cov-report=html
+make test-cov
+# or
+python -m pytest tests/ --cov=src --cov-report=html
 ```
 
 ## Import Convention
 
-All imports should use the `code.` prefix:
+All imports should use the `src.` prefix:
 ```python
-from code.alignment_analysis.align import align_data
-from code.config.paths import DATA_DIR, get_experiment_path
-from code.orientation_analysis import analyze_gravity
+from src.analysis.alignment import align_data
+from src.core.paths import DATA_DIR, get_experiment_path
+from src.analysis.orientation import analyze_gravity
+from src.apps.dashboard import app
+from src.analysis.rpm import RPMFrame
 ```
 
 Never use:
 - `sys.path.append()` or `sys.path.insert()`
+- Old package names (`hovercraft_analysis.`, `code.`)
 - Relative imports across modules
 - Hardcoded file paths
 
 ## Configuration
 
-The main configuration files are located in `code/config/`:
-- `paths.py` - Centralized path management
-- `experiment_mapping.json` - Maps experiments to evaluation categories
-- `sensor_orientations.json` - Sensor configuration data
-- Various YAML files for module-specific settings
+The master configuration system is centralized in `/config/`:
+- `pipeline.yaml` - Master configuration file with environment support
+- `/experiments/` - Experiment mappings and categories
+- `/sensors/` - Sensor specifications and orientations
+- `/processing/` - Module-specific processing configurations
+
+### Using Configuration
+```python
+from src.core import get_config
+
+# Get configuration manager
+config = get_config()
+
+# Access configuration values
+project_name = config.get('project.name')
+data_root = config.get('paths.data_root')
+
+# Get paths as Path objects
+data_path = config.get_path('paths.data_root')
+```
 
 ## Common Tasks
 
 ### Running the Dashboard
 ```bash
-python code/scripts/dashboard_app.py
+# Using installed entry point
+hovercraft-dashboard
+
+# Or run as module
+python -m src.scripts.dashboard_app
 ```
 
 ### Running Alignment Analysis
 ```bash
-python code/scripts/run_alignment.py
+# Using installed entry point
+hovercraft-align --experiment 007_Fast_stbd_turn_1
+
+# Or run as module
+python -m src.scripts.run_alignment
 ```
 
 ### Processing Timestamp Analysis
 ```bash
-python code/scripts/run_timestamp_analysis_standalone.py
+# Using installed entry point
+hovercraft-timestamp --experiment 016_Straight_cruise_1
+
+# Or run as module
+python -m src.scripts.run_timestamp_analysis_standalone
 ```
 
 ## Data Access
 
 Always use the centralized path helpers:
 ```python
-from code.config.paths import get_experiment_path
+from src.core.paths import get_experiment_path
+from src.core.io import load_experiment_data
 
-# Get path to an experiment
+# Load all data for an experiment
+data = load_experiment_data("016_Straight_cruise_1", "afternoon")
+gps_data = data['gps']
+accel_data = data['Sensor_3_accel']
+
+# Or get path to an experiment
 exp_path = get_experiment_path("016_Straight_cruise_1", "afternoon")
-
-# Access data files
 gps_data = pd.read_csv(exp_path / "GPS" / "GPS_016_Straight_cruise_1.csv")
 ```
 
 ## Troubleshooting
 
 ### Import Errors
-- Ensure you're using the `code.` prefix for all imports
-- Check that you're in the project root directory when running scripts
-- Verify all dependencies are installed: `pip install -r requirements.txt`
+- Ensure you're using the `src.` prefix for all imports
+- Install the package with `pip install -e .` to enable imports from anywhere
+- Verify all dependencies are installed: `pip install -e ".[dev]"`
 
 ### Data Not Found
-- Check that the data directory exists and contains the experimental data
+- Check that the data directory exists at `/data/raw/`
 - Use `get_experiment_path()` helper function instead of hardcoded paths
 - Verify the experiment name and time_of_day parameters
 
 ### Test Failures
 - Run tests from the project root directory
-- Ensure test data files are available
-- Check that all module dependencies are installed
+- Ensure virtual environment is activated
+- Check that all development dependencies are installed
 
 ## Code Style
 
@@ -157,16 +206,44 @@ gps_data = pd.read_csv(exp_path / "GPS" / "GPS_016_Straight_cruise_1.csv")
 - Add docstrings to all public functions and classes
 - Follow PEP 8 style guidelines
 - Keep functions focused and small
+- Run linting and formatting:
+  ```bash
+  make lint        # Check code quality
+  make format      # Auto-format code
+  ```
 
 ## Getting Help
 
 - Check the CLAUDE.md file for detailed development guidelines
-- Review module-specific README files in each subdirectory
+- Review the REPOSITORY_STRUCTURE.md for detailed structure information
 - Consult the documentation in the `/docs` directory
+- Report issues at the project's GitHub repository
 
-## Next Steps
+## Development Workflow
 
-After Phase 2 implementation, you'll be able to:
-- Install the package with `pip install -e .`
-- Use command-line tools like `hovercraft-align` and `hovercraft-dashboard`
-- Run linting and formatting with `make lint` and `make format`
+1. **Before making changes**:
+   ```bash
+   make test-fast   # Ensure tests pass
+   make lint        # Check code quality
+   ```
+
+2. **After making changes**:
+   ```bash
+   make test-fast   # Verify tests still pass
+   make lint        # Ensure code quality
+   ```
+
+3. **Before committing**:
+   ```bash
+   make check-quality   # Run all quality checks
+   ```
+
+## Available Make Commands
+
+- `make test` - Run all tests
+- `make test-fast` - Run tests quickly (no coverage)
+- `make test-cov` - Run tests with coverage report
+- `make lint` - Run all linters
+- `make format` - Auto-format code
+- `make check-quality` - Run all quality checks
+- `make clean` - Clean temporary files

--- a/data/processed/rpm/wp4/WP4_TEST_RESULTS.md
+++ b/data/processed/rpm/wp4/WP4_TEST_RESULTS.md
@@ -25,7 +25,7 @@
 
 ### Test 2.1: Dynamic Maneuver (007_Fast_stbd_turn_1)
 
-**Command**: `python -m code.rpm_estimation.cli --wp 4 --exp 007_Fast_stbd_turn_1 --session afternoon --plot`
+**Command**: `python -m src.analysis.rpm.cli --wp 4 --exp 007_Fast_stbd_turn_1 --session afternoon --plot`
 
 **Results**:
 - ✅ Fusion completed successfully

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,13 @@ A data analysis pipeline for processing, analyzing, and visualizing data collect
 
 This repository contains the data and tools for analyzing hovercraft performance based on GPS and IMU sensor readings collected during various test maneuvers. Key components include:
 
-- Raw experimental data stored in `02_Evaluation_Experiments/`.
-- A Dash web application for interactive visualization (`hovercraft_data_analysis/dashboard_app/`).
+- Raw experimental data stored in `/data/raw/`.
+- A Dash web application for interactive visualization (`/src/apps/dashboard/`).
 - Supporting Python modules and potentially Jupyter notebooks for specific analyses.
 
-## Data Structure (`02_Evaluation_Experiments/`)
+## Data Structure (`/data/raw/`)
 
-Experimental data is organized within the `02_Evaluation_Experiments/` directory using a nested structure:
+Experimental data is organized within the `/data/raw/` directory using a nested structure:
 
 ```
 Category/

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -223,7 +223,7 @@ If you have code using old hardcoded paths:
 
 ```python
 # Old way (don't do this)
-data_path = "../../02_Evaluation_Experiments/afternoon/007_Fast_stbd_turn_1"
+data_path = "../data/raw/afternoon/Experiments/007_Fast_stbd_turn_1"
 
 # New way
 from src.core import get_experiment_path

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -55,11 +55,10 @@ The dashboard will be available at http://localhost:8050
 analysis-pipeline/
 ├── config/           # Configuration files
 ├── src/              # Source code
-│   ├── core/
-│       ├── core/     # Core utilities
-│       ├── analysis/ # Analysis modules
-│       ├── apps/     # Applications (dashboard)
-│       └── scripts/  # CLI scripts
+│   ├── core/         # Core utilities
+│   ├── analysis/     # Analysis modules
+│   ├── apps/         # Applications (dashboard)
+│   └── scripts/      # CLI scripts
 ├── data/             # Experimental data
 │   ├── raw/          # Raw sensor data
 │   └── processed/    # Processed outputs

--- a/docs/results/rpm_estimation/wp4_fusion/WP4_TESTING_ACTION_PLAN.md
+++ b/docs/results/rpm_estimation/wp4_fusion/WP4_TESTING_ACTION_PLAN.md
@@ -30,31 +30,31 @@ The critical RPM sweep test (026) cannot be completed because:
 ### Step 1: Generate Missing WP-1 Data (Priority: HIGH)
 ```bash
 # Generate WP-1 for experiment 003
-python -m code.rpm_estimation.cli --wp 1 --exp 003_Waiting_for_departure --session afternoon
+python -m src.analysis.rpm.cli --wp 1 --exp 003_Waiting_for_departure --session afternoon
 
 # Generate WP-1 for experiment 026 (CRITICAL)
-python -m code.rpm_estimation.cli --wp 1 --exp 026_Engine_rpm_sweep --session afternoon
+python -m src.analysis.rpm.cli --wp 1 --exp 026_Engine_rpm_sweep --session afternoon
 ```
 
 ### Step 2: Generate WP-2 Data for 011
 ```bash
 # Complete WP-2 for static experiment
-python -m code.rpm_estimation.cli --wp 2 --exp 011_Static_stbd_1 --session afternoon
+python -m src.analysis.rpm.cli --wp 2 --exp 011_Static_stbd_1 --session afternoon
 ```
 
 ### Step 3: Generate WP-3 Data
 ```bash
 # After WP-1 is complete, generate STFT results
-python -m code.rpm_estimation.cli --wp 3 --exp 003_Waiting_for_departure --session afternoon
-python -m code.rpm_estimation.cli --wp 3 --exp 026_Engine_rpm_sweep --session afternoon
-python -m code.rpm_estimation.cli --wp 3 --exp 011_Static_stbd_1 --session afternoon
+python -m src.analysis.rpm.cli --wp 3 --exp 003_Waiting_for_departure --session afternoon
+python -m src.analysis.rpm.cli --wp 3 --exp 026_Engine_rpm_sweep --session afternoon
+python -m src.analysis.rpm.cli --wp 3 --exp 011_Static_stbd_1 --session afternoon
 ```
 
 ### Step 4: Run Complete WP-4 Test Suite
 
 #### 4.1 Static Test (003_Waiting_for_departure)
 ```bash
-python -m code.rpm_estimation.cli --wp 4 --exp 003_Waiting_for_departure --session afternoon --plot
+python -m src.analysis.rpm.cli --wp 4 --exp 003_Waiting_for_departure --session afternoon --plot
 ```
 Expected:
 - Steady RPM ~700-800
@@ -64,7 +64,7 @@ Expected:
 
 #### 4.2 Critical RPM Sweep Test (026_Engine_rpm_sweep)
 ```bash
-python -m code.rpm_estimation.cli --wp 4 --exp 026_Engine_rpm_sweep --session afternoon --plot
+python -m src.analysis.rpm.cli --wp 4 --exp 026_Engine_rpm_sweep --session afternoon --plot
 ```
 Success Criteria:
 - **<2% NaN frames** (critical metric)
@@ -74,17 +74,17 @@ Success Criteria:
 
 #### 4.3 Additional Static Test (011_Static_stbd_1)
 ```bash
-python -m code.rpm_estimation.cli --wp 4 --exp 011_Static_stbd_1 --session afternoon --plot
+python -m src.analysis.rpm.cli --wp 4 --exp 011_Static_stbd_1 --session afternoon --plot
 ```
 
 ### Step 5: Advanced Feature Testing
 ```bash
 # Test median fusion strategy
-python -m code.rpm_estimation.cli --wp 4 --exp 026_Engine_rpm_sweep --session afternoon \
+python -m src.analysis.rpm.cli --wp 4 --exp 026_Engine_rpm_sweep --session afternoon \
     --fusion-strategy median --plot
 
 # Test stricter sensor requirements
-python -m code.rpm_estimation.cli --wp 4 --exp 026_Engine_rpm_sweep --session afternoon \
+python -m src.analysis.rpm.cli --wp 4 --exp 026_Engine_rpm_sweep --session afternoon \
     --min-sensors 2 --plot
 
 # Test shorter interpolation window


### PR DESCRIPTION
Update all documentation files to use the current repository structure:
- Replace references to removed /code/ directory with /src/
- Update import examples from hovercraft_analysis. to src.
- Fix paths referencing old 02_Evaluation_Experiments to /data/raw/
- Update CLI commands to use new module paths
- Fix project structure diagrams and examples

Files updated:
- SETUP.md: Complete rewrite with current structure and imports
- README.md: Fix Python API import examples
- docs/getting_started.md: Remove duplicate core/ in structure
- docs/README.md: Update data directory references
- docs/configuration_guide.md: Fix hardcoded path example
- docs/results/rpm_estimation/wp4_fusion/: Update CLI commands
- data/processed/rpm/wp4/: Update test command references